### PR TITLE
add DDEV support

### DIFF
--- a/.ddev/addon-metadata/ddev-opensearch/manifest.yaml
+++ b/.ddev/addon-metadata/ddev-opensearch/manifest.yaml
@@ -1,0 +1,9 @@
+name: ddev-opensearch
+repository: netz98/ddev-opensearch
+version: 1.0.4
+install_date: "2024-01-17T13:17:37+01:00"
+project_files:
+    - opensearch
+    - docker-compose.opensearch.yaml
+global_files: []
+removal_actions: []

--- a/.ddev/addon-metadata/rabbitmq/manifest.yaml
+++ b/.ddev/addon-metadata/rabbitmq/manifest.yaml
@@ -1,0 +1,11 @@
+name: rabbitmq
+repository: b13/ddev-rabbitmq
+version: 0.0.4
+install_date: "2024-01-17T13:19:51+01:00"
+project_files:
+    - docker-compose.rabbitmq.yaml
+    - commands/rabbitmq/
+    - rabbitmq/config.yaml
+    - rabbitmq/schema.json
+global_files: []
+removal_actions: []

--- a/.ddev/addon-metadata/redis/manifest.yaml
+++ b/.ddev/addon-metadata/redis/manifest.yaml
@@ -1,0 +1,19 @@
+name: redis
+repository: ddev/ddev-redis-7
+version: v2.6.1
+install_date: "2024-01-17T13:15:43+01:00"
+project_files:
+    - commands/redis/redis
+    - commands/redis/redis-flush
+    - redis/redis.conf
+    - redis/advanced.conf
+    - redis/append.conf
+    - redis/general.conf
+    - redis/io.conf
+    - redis/memory.conf
+    - redis/network.conf
+    - redis/security.conf
+    - redis/snapshots.conf
+    - docker-compose.redis.yaml
+global_files: []
+removal_actions: []

--- a/.ddev/addon-metadata/varnish/manifest.yaml
+++ b/.ddev/addon-metadata/varnish/manifest.yaml
@@ -1,0 +1,10 @@
+name: varnish
+repository: ddev/ddev-varnish
+version: v0.2.2
+install_date: "2024-01-17T13:14:06+01:00"
+project_files:
+    - docker-compose.varnish.yaml
+    - varnish
+    - commands/varnish
+global_files: []
+removal_actions: []

--- a/.ddev/commands/host/development
+++ b/.ddev/commands/host/development
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## Description: Set Magento to developer mode
+## Usage: development
+## Example: "ddev development"
+## ProjectTypes: magento2
+## ExecRaw: true
+
+ddev composer dump
+ddev exec rm -rf generated/*
+ddev magento deploy:mode:set -s developer
+ddev restart

--- a/.ddev/commands/host/images
+++ b/.ddev/commands/host/images
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Description: Copies product-images
+## Usage: images
+## Example: "ddev images"
+## ProjectTypes: magento2
+## ExecRaw: true
+
+ddev exec mkdir -p pub/media/catalog/product/S/h
+ddev exec cp product-images/Sh*.png pub/media/catalog/product/S/h/

--- a/.ddev/commands/host/large
+++ b/.ddev/commands/host/large
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+## Description: Installs large dataset
+## Usage: large
+## Example: "ddev large"
+## ProjectTypes: magento2
+## ExecRaw: true
+
+ddev import-db --file=db.large.sql.gz
+ddev magento setup:db-schema:upgrade
+ddev magento app:config:import

--- a/.ddev/commands/host/magento-install
+++ b/.ddev/commands/host/magento-install
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+## Description: Run Magento install inside the web container
+## Usage: magento-install
+## Example: "ddev magento-install"
+## ProjectTypes: magento2
+## ExecRaw: true
+
+ddev composer install --no-dev
+
+ddev magento setup:install --backend-frontname=backend \
+    --amqp-host=rabbitmq --amqp-port=5672 --amqp-user=rabbitmq --amqp-password=rabbitmq \
+    --db-host=db --db-name=db --db-user=db --db-password=db \
+    --search-engine=opensearch --opensearch-host=opensearch \
+    --opensearch-port=9200 --opensearch-index-prefix=magento2 --opensearch-enable-auth=0 --opensearch-timeout=15 \
+    --http-cache-hosts=varnish:80 \
+    --session-save=redis --session-save-redis-host=redis --session-save-redis-password=redis --session-save-redis-port=6379 --session-save-redis-db=2 --session-save-redis-max-concurrency=20 \
+    --cache-backend=redis --cache-backend-redis-server=redis --cache-backend-redis-password=redis --cache-backend-redis-db=0 --cache-backend-redis-port=6379 \
+    --page-cache=redis --page-cache-redis-server=redis --page-cache-redis-password=redis --page-cache-redis-db=1 --page-cache-redis-port=6379
+ddev magento config:set --lock-env web/unsecure/base_url "${DDEV_PRIMARY_URL}/"
+ddev magento config:set --lock-env web/secure/base_url "${DDEV_PRIMARY_URL}/"
+ddev magento config:set --lock-env web/secure/offloader_header X-Forwarded-Proto
+ddev magento config:set --lock-env web/secure/use_in_frontend 1
+ddev magento config:set --lock-env web/secure/use_in_adminhtml 1
+ddev magento config:set --lock-env web/seo/use_rewrites 1
+ddev magento config:set --lock-env system/full_page_cache/caching_application 2
+ddev magento config:set --lock-env system/full_page_cache/ttl 604800
+ddev magento config:set --lock-env dev/static/sign 0
+ddev magento cache:disable block_html
+ddev magento cache:flush
+
+ddev development
+
+ddev images
+
+ddev small

--- a/.ddev/commands/host/medium
+++ b/.ddev/commands/host/medium
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+## Description: Installs medium dataset
+## Usage: medium
+## Example: "ddev medium"
+## ProjectTypes: magento2
+## ExecRaw: true
+
+ddev import-db --file=db.medium.sql.gz
+ddev magento setup:db-schema:upgrade
+ddev magento app:config:import
+ddev magento index:reset catalogsearch_fulltext
+ddev magento index:reindex catalogsearch_fulltext

--- a/.ddev/commands/host/msi-stock
+++ b/.ddev/commands/host/msi-stock
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+## Description: MSI-Stock
+## Usage: msi-stock
+## Example: "ddev msi-stock"
+## ProjectTypes: magento2
+## ExecRaw: true
+
+echo "insert into inventory_source_item (sku, source_code, quantity, status) select c.sku, 'eu', si.qty, 1 from cataloginventory_stock_item si inner join catalog_product_entity c on c.entity_id = si.product_id where type_id = 'simple' on duplicate key update quantity = VALUES(quantity), status = VALUES(status)" | ddev mysql
+echo "insert into inventory_source_item (sku, source_code, quantity, status) select c.sku, 'us', si.qty, 1 from cataloginventory_stock_item si inner join catalog_product_entity c on c.entity_id = si.product_id where type_id = 'simple' on duplicate key update quantity = VALUES(quantity), status = VALUES(status)" | ddev mysql

--- a/.ddev/commands/host/production
+++ b/.ddev/commands/host/production
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+## Description: Set Magento to production mode
+## Usage: production
+## Example: "ddev production"
+## ProjectTypes: magento2
+## ExecRaw: true
+
+ddev composer dump
+ddev magento deploy:mode:set -s production
+ddev magento setup:di:compile
+ddev magento setup:static-content:deploy
+ddev composer dump -o --apcu
+ddev restart

--- a/.ddev/commands/host/reindex
+++ b/.ddev/commands/host/reindex
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+## Description: Reindexes Magento
+## Usage: reindex
+## Example: "ddev reindex"
+## ProjectTypes: magento2
+## ExecRaw: true
+
+ddev magento index:reindex inventory cataloginventory_stock catalog_category_product

--- a/.ddev/commands/host/small
+++ b/.ddev/commands/host/small
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+## Description: Installs small dataset
+## Usage: small
+## Example: "ddev small"
+## ProjectTypes: magento2
+## ExecRaw: true
+
+ddev import-db --file=db.small.sql
+ddev magento setup:db-schema:upgrade
+ddev magento app:config:import
+ddev magento index:reset catalogsearch_fulltext
+ddev magento index:reindex catalogsearch_fulltext

--- a/.ddev/commands/rabbitmq/rabbitmq
+++ b/.ddev/commands/rabbitmq/rabbitmq
@@ -1,0 +1,185 @@
+#! /usr/bin/env bash
+#ddev-generated
+
+## Description: Manage parts of rabbitmq
+## Usage: rabbitmq
+## Example: ddev rabbitmq
+
+# @todo
+# * Test amqp, whatever it is doing
+
+CMD=$1
+
+# Subcommands allowed to watch
+ALLOWED_DISPLAY_ARGUMENTS=("overview" "connections" "channels" "consumers" "exchanges" "queues" "bindings" "users" "vhosts" "permissions" "nodes" "parameters" "policies" "operator_policies" "vhost_limits" )
+
+YAML_FILE=/mnt/ddev_config/rabbitmq/config.yaml
+
+function watcher() {
+  subcommand=$1
+  interval=$2
+
+  if [ "$subcommand" = "overview" ]; then
+    display_argument="show $subcommand"
+  else
+    display_argument="list $subcommand"
+  fi
+
+  if [[ " ${ALLOWED_DISPLAY_ARGUMENTS[*]} " = *" $subcommand "* ]]; then
+      while true; do
+          output=$(rabbitmqadmin "$display_argument" -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS")
+          clear
+          echo "$output"
+          echo "Refresh interval: $interval sec - $(date)"
+          sleep $interval
+      done
+  else
+    echo -e "Watch subcommand '$subcommand' not allowed, use one of these:\n * ${ALLOWED_DISPLAY_ARGUMENTS[*]}"
+  fi
+}
+
+function add_vhosts() {
+  vhosts_json=$(rabbitmqctl list_vhosts --formatter json)
+  readarray vhosts_existing < <(echo "$vhosts_json" | yq -o=y -I=0 '.[].name' -)
+  readarray vhosts < <(yq -o=j -I=0 '.vhost[]' $YAML_FILE )
+  for vhost in "${vhosts[@]}"; do
+    name=$(echo "$vhost" | yq '.name // ""' -)
+
+    if [[ ! " ${vhosts_existing[*]} " =~ $name ]]; then
+      description=$(echo "$vhost" | yq '.description // ""' -)
+      description_option=$([ -z "$description" ] && echo "" || echo "--description \"$description\"")
+
+      default_queue_type=$(echo "$vhost" | yq '.default-queue-type // ""' -)
+      default_queue_type_option=$([ -z "$default_queue_type" ] && echo "" || echo "--default-queue-type $default_queue_type")
+
+      tags=$(echo "$vhost" | yq '.tags[]' -)
+      comma_separated=$(echo "${tags[*]}" | xargs | sed -e 's/ /,/g')
+      tags_option=$([ -z "$comma_separated" ] && echo "" || echo "--tags $comma_separated")
+
+      rabbitmqctl add_vhost $name $description_option $tags_option $default_queue_type_option || exit 1
+    else
+      echo "ℹ️vhost '$name' already exists! To update a vhost please delete it first."
+    fi
+  done
+}
+
+function add_queues() {
+  readarray queues < <(yq -o=j -I=0 '.queue[]' $YAML_FILE )
+  for queue in "${queues[@]}"; do
+    name=$(echo "$queue" | yq '.name' -)
+    vhost=$(echo "$queue" | yq '.vhost // "/"' -)
+
+    queues_existing=$(rabbitmqctl list_queues --silent --formatter json --vhost "$vhost")
+    readarray queues_existing < <(echo "$queues_existing" | yq -o=y -I=0 '.[].name' -)
+
+    if [[ ! " ${queues_existing[*]} " =~ $name ]]; then
+      durable=$(echo "$queue" | yq '.durable // "true"' -)
+      rabbitmqadmin declare queue --vhost="$vhost" name="$name" durable="$durable"  -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" || exit 1
+    else
+      echo "ℹ️Queue '$name' already exists in vhost '$vhost'! To update the queue please delete it first."
+    fi
+  done
+}
+
+function add_users() {
+  users_json=$(rabbitmqctl list_users --silent --formatter json)
+  readarray users_existing < <(echo "$users_json" | yq -o=y -I=0 '.[].user' -)
+  readarray users < <(yq -o=j -I=0 '.user[]' $YAML_FILE )
+
+  for user in "${users[@]}"; do
+    name=$(echo "$user" | yq '.name // ""' -)
+
+    if [[ ! " ${users_existing[*]} " =~ $name ]]; then
+      password=$(echo "$user" | yq '.password // ""' -)
+      rabbitmqctl add_user "$name" "$password" || exit 1
+
+      tags=$(echo "$user" | yq '.tags[]' -)
+      comma_separated=$(echo "${tags[*]}" | xargs | sed -e 's/ /,/g')
+      rabbitmqctl set_user_tags "$name" "$comma_separated" || exit 1
+
+      permissions=$(echo "$user" | yq '.permissions[]' -)
+      for permission in "${permissions[@]}"; do
+        vhost=$(echo "$permission" | yq '.vhost // "/"' -)
+        conf=$(echo "$permission" | yq '.conf // ".*"' -)
+        write=$(echo "$permission" | yq '.write // ".*"' -)
+        read=$(echo "$permission" | yq '.read // ".*"' -)
+        rabbitmqctl set_permissions -p "$vhost" "$name" "$conf" "$write" "$read" || exit 1
+      done
+    else
+      echo "ℹ️User '$name' already exists! To update a user please delete it first."
+    fi
+  done
+}
+
+# The RabbitMQ container does not contain yq
+# But it is needed to apply the configuration
+if ! command -v yq >/dev/null 2>&1; then
+    apk add yq > /dev/null 2>&1
+fi
+
+case $CMD in
+  apply)
+    echo "Apply config $YAML_FILE"
+
+    plugins_array=$(yq eval '.plugins[]' "$YAML_FILE")
+    plugins=$(echo "${plugins_array[*]}" | tr '\n' ' ' | xargs)
+    rabbitmq-plugins enable "$plugins"
+
+    add_vhosts
+    # Ensure the default admin "rabbitmq" has permissions for all virtual hosts
+    rabbitmqctl set_permissions_globally "rabbitmq" ".*" ".*" ".*" > /dev/null
+    add_queues
+    add_users
+    ;;
+
+  wipe)
+    users_json=$(rabbitmqctl list_users --silent --formatter json)
+    readarray users_existing < <(echo "$users_json" | yq -o=y -I=0 '.[].user' -)
+    for user in "${users_existing[@]}"; do
+      user=$(echo -n "$user" | tr -d '\n')
+      if [ "$user" != "rabbitmq" ]; then
+        rabbitmqctl delete_user "$user"
+      fi
+    done
+
+    vhosts_json=$(rabbitmqctl list_vhosts --formatter json)
+    readarray vhosts_existing < <(echo "$vhosts_json" | yq -o=y -I=0 '.[].name' -)
+    for host in "${vhosts_existing[@]}"; do
+      host=$(echo -n "$host" | tr -d '\n')
+      if [ "$host" != "/" ]; then
+        rabbitmqctl delete_vhost "$host"
+      fi
+    done
+    ;;
+  watch)
+    subcommand="$2"
+    subcommand=${subcommand:=overview}
+    interval="$3"
+    interval=${interval:=2}
+
+    watcher "$subcommand" "$interval"
+    ;;
+
+  --help|*)
+    echo "——————————————"
+    echo -e "\033[1mExample Usage:\033[0m"
+    echo "——————————————"
+    echo -e "\033[1mApply\033[0m"
+    echo "—————"
+    echo "Create queues, users and add 'plugins' according to configuration (see .ddev/rabbitmq/config.yaml)"
+    echo "👉 ddev rabbitmq apply"
+    echo ""
+    echo -e "\033[1mWipe\033[0m"
+    echo "—————"
+    echo "Clear vhosts, queues and users (only vhost '/' and user 'rabbitmq' are kept)"
+    echo "👉 ddev rabbitmq wipe"
+    echo ""
+    echo -e "\033[1mWatcher\033[0m"
+    echo "———————"
+    echo "A little wrapper around 'rabbitmqadmin' to be able to watch e.g. queues"
+    echo "👉 ddev rabbitmq watch <command> <interval>"
+    echo -e "Possible <command> values:\n * ${ALLOWED_DISPLAY_ARGUMENTS[*]}"
+    echo ""
+    echo -e "ℹ️ To use the rabbitmqadmin command run 'ddev rabbitmqadmin --help' for details.\nThis command passes all values to rabbitmqadmin within the container."
+    ;;
+esac

--- a/.ddev/commands/rabbitmq/rabbitmqadmin
+++ b/.ddev/commands/rabbitmq/rabbitmqadmin
@@ -1,0 +1,8 @@
+#!/bin/bash
+#ddev-generated
+
+## Description: Manage parts of rabbitmq
+## Usage: rabbitmqadmin [options] subcommand
+## Example: ddev rabbitmqadmin --help
+
+rabbitmqadmin -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" $@

--- a/.ddev/commands/rabbitmq/rabbitmqctl
+++ b/.ddev/commands/rabbitmq/rabbitmqctl
@@ -1,0 +1,8 @@
+#!/bin/bash
+#ddev-generated
+
+## Description: Manage parts of rabbitmq
+## Usage: rabbitmqctl [--node <node>] [--timeout <timeout>] [--longnames] [--quiet] <command> [<command options>]
+## Example: ddev rabbitmqctl --help
+
+rabbitmqctl $@

--- a/.ddev/commands/redis/redis
+++ b/.ddev/commands/redis/redis
@@ -1,0 +1,7 @@
+#!/bin/sh
+#ddev-generated
+## Description: Run redis-cli inside the redis container
+## Usage: redis [flags] [args]
+## Example: "redis KEYS *" or "ddev redis-cli INFO" or "ddev redis-cli --version"
+
+redis-cli -p 6379 -h redis -a redis --no-auth-warning "$@"

--- a/.ddev/commands/redis/redis-flush
+++ b/.ddev/commands/redis/redis-flush
@@ -1,0 +1,7 @@
+#!/bin/sh
+#ddev-generated
+## Description: Run redis-cli inside the redis container
+## Usage: redis-flush
+## Example: "redis-flush"
+
+redis-cli -a redis --no-auth-warning FLUSHALL ASYNC

--- a/.ddev/commands/varnish/varnishadm
+++ b/.ddev/commands/varnish/varnishadm
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Control a running Varnish instance
+## Usage: varnishadm [flags] [args]
+## Example: "ddev varnishadm"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishadm "$@"

--- a/.ddev/commands/varnish/varnishd
+++ b/.ddev/commands/varnish/varnishd
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Varnish-cli
+## Usage: varnishd [flags] [args]
+## Example: "ddev varnishd -d" for CLI in foreground.
+## Example: "ddev varnishd -T" to connect with varnishadm or telnet.
+## Example: "ddev varnishd -M" to connect back to a listening service pushing the CLI to that service.
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishd "$@"

--- a/.ddev/commands/varnish/varnishhist
+++ b/.ddev/commands/varnish/varnishhist
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Display Varnish request histogram
+## Usage: varnishhist [flags] [args]
+## Example: "ddev varnishhist"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishhist "$@"

--- a/.ddev/commands/varnish/varnishlog
+++ b/.ddev/commands/varnish/varnishlog
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Display Varnish logs
+## Usage: varnishlog [flags] [args]
+## Example: "ddev varnishlog"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishlog "$@"

--- a/.ddev/commands/varnish/varnishncsa
+++ b/.ddev/commands/varnish/varnishncsa
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Display Varnish logs in Apache / NCSA combined log format
+## Usage: varnishncsa [flags] [args]
+## Example: "ddev varnishncsa"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishncsa "$@"

--- a/.ddev/commands/varnish/varnishstat
+++ b/.ddev/commands/varnish/varnishstat
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Display Varnish Cache statistics
+## Usage: varnishstat [flags] [args]
+## Example: "ddev varnishstat"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishstat "$@"

--- a/.ddev/commands/varnish/varnishtest
+++ b/.ddev/commands/varnish/varnishtest
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Test program for Varnish
+## Usage: varnishtest [flags] [args]
+## Example: "ddev varnishtest"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishtest "$@"

--- a/.ddev/commands/varnish/varnishtop
+++ b/.ddev/commands/varnish/varnishtop
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## #ddev-generated
+## Description: Display Varnish log entry ranking
+## Usage: varnishtop [flags] [args]
+## Example: "ddev varnishtop"
+
+# This example runs inside the varnish container.
+# Note that this requires that /mnt/ddev_config be mounted
+# into the varnish container.
+
+varnishtop "$@"

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,278 @@
+name: performance-training
+type: magento2
+docroot: pub
+php_version: "8.1"
+webserver_type: nginx-fpm
+xdebug_enabled: false
+additional_hostnames: []
+additional_fqdns: []
+database:
+    type: mariadb
+    version: "10.4"
+use_dns_when_possible: true
+composer_version: "2"
+web_environment: []
+hooks:
+    post-start:
+        - exec-host: "[ -f bin/magento ] || ddev magento-install"
+
+# Key features of DDEV's config.yaml:
+
+# name: <projectname> # Name of the project, automatically provides
+#   http://projectname.ddev.site and https://projectname.ddev.site
+
+# type: <projecttype>  # backdrop, craftcms, django4, drupal6/7/8/9/10, laravel, magento, magento2, php, python, shopware6, silverstripe, typo3, wordpress
+# See https://ddev.readthedocs.io/en/latest/users/quickstart/ for more
+# information on the different project types
+
+# docroot: <relative_path> # Relative path to the directory containing index.php.
+
+# php_version: "8.1"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"
+
+# You can explicitly specify the webimage but this
+# is not recommended, as the images are often closely tied to DDEV's' behavior,
+# so this can break upgrades.
+
+# webimage: <docker_image>  # nginx/php docker image.
+
+# database:
+#   type: <dbtype> # mysql, mariadb, postgres
+#   version: <version> # database version, like "10.4" or "8.0"
+#   MariaDB versions can be 5.5-10.8 and 10.11, MySQL versions can be 5.5-8.0
+#   PostgreSQL versions can be 9-16.
+
+# router_http_port: <port>  # Port to be used for http (defaults to global configuration, usually 80)
+# router_https_port: <port> # Port for https (defaults to global configuration, usually 443)
+
+# xdebug_enabled: false  # Set to true to enable Xdebug and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xdebug" to enable Xdebug and "ddev xdebug off" to disable it work better,
+# as leaving Xdebug enabled all the time is a big performance hit.
+
+# xhprof_enabled: false  # Set to true to enable Xhprof and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xhprof" to enable Xhprof and "ddev xhprof off" to disable it work better,
+# as leaving Xhprof enabled all the time is a big performance hit.
+
+# webserver_type: nginx-fpm, apache-fpm, or nginx-gunicorn
+
+# timezone: Europe/Berlin
+# This is the timezone used in the containers and by PHP;
+# it can be set to any valid timezone,
+# see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# For example Europe/Dublin or MST7MDT
+
+# composer_root: <relative_path>
+# Relative path to the Composer root directory from the project root. This is
+# the directory which contains the composer.json and where all Composer related
+# commands are executed.
+
+# composer_version: "2"
+# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
+# to use the latest major version available at the time your container is built.
+# It is also possible to use each other Composer version channel. This includes:
+#   - 2.2 (latest Composer LTS version)
+#   - stable
+#   - preview
+#   - snapshot
+# Alternatively, an explicit Composer version may be specified, for example "2.2.18".
+# To reinstall Composer after the image was built, run "ddev debug refresh".
+
+# nodejs_version: "18"
+# change from the default system Node.js version to any other version.
+# Numeric version numbers can be complete (i.e. 18.15.0) or
+# incomplete (18, 17.2, 16). 'lts' and 'latest' can be used as well along with
+# other named releases.
+# see https://www.npmjs.com/package/n#specifying-nodejs-versions
+# Note that you can continue using 'ddev nvm' or nvm inside the web container
+# to change the project's installed node version if you need to.
+
+# additional_hostnames:
+#  - somename
+#  - someothername
+# would provide http and https URLs for "somename.ddev.site"
+# and "someothername.ddev.site".
+
+# additional_fqdns:
+#  - example.com
+#  - sub1.example.com
+# would provide http and https URLs for "example.com" and "sub1.example.com"
+# Please take care with this because it can cause great confusion.
+
+# upload_dirs: "custom/upload/dir"
+#
+# upload_dirs:
+#   - custom/upload/dir
+#   - ../private
+#
+# would set the destination paths for ddev import-files to <docroot>/custom/upload/dir
+# When Mutagen is enabled this path is bind-mounted so that all the files
+# in the upload_dirs don't have to be synced into Mutagen.
+
+# disable_upload_dirs_warning: false
+# If true, turns off the normal warning that says
+# "You have Mutagen enabled and your 'php' project type doesn't have upload_dirs set"
+
+# ddev_version_constraint: ""
+# Example:
+# ddev_version_constraint: ">= 1.22.4"
+# This will enforce that the running ddev version is within this constraint.
+# See https://github.com/Masterminds/semver#checking-version-constraints for
+# supported constraint formats
+
+# working_dir:
+#   web: /var/www/html
+#   db: /home
+# would set the default working directory for the web and db services.
+# These values specify the destination directory for ddev ssh and the
+# directory in which commands passed into ddev exec are run.
+
+# omit_containers: [db, ddev-ssh-agent]
+# Currently only these containers are supported. Some containers can also be
+# omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
+# the "db" container, several standard features of DDEV that access the
+# database container will be unusable. In the global configuration it is also
+# possible to omit ddev-router, but not here.
+
+# performance_mode: "global"
+# DDEV offers performance optimization strategies to improve the filesystem
+# performance depending on your host system. Should be configured globally.
+#
+# If set, will override the global config. Possible values are:
+#   - "global":  uses the value from the global config.
+#   - "none":    disables performance optimization for this project.
+#   - "mutagen": enables Mutagen for this project.
+#   - "nfs":     enables NFS for this project.
+#
+# See https://ddev.readthedocs.io/en/latest/users/install/performance/#nfs
+# See https://ddev.readthedocs.io/en/latest/users/install/performance/#mutagen
+
+# fail_on_hook_fail: False
+# Decide whether 'ddev start' should be interrupted by a failing hook
+
+# host_https_port: "59002"
+# The host port binding for https can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_webserver_port: "59001"
+# The host port binding for the ddev-webserver can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_db_port: "59002"
+# The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
+# unless explicitly specified.
+
+# mailpit_http_port: "8025"
+# mailpit_https_port: "8026"
+# The Mailpit ports can be changed from the default 8025 and 8026
+
+# host_mailpit_port: "8025"
+# The mailpit port is not normally bound on the host at all, instead being routed
+# through ddev-router, but it can be bound directly to localhost if specified here.
+
+# webimage_extra_packages: [php7.4-tidy, php-bcmath]
+# Extra Debian packages that are needed in the webimage can be added here
+
+# dbimage_extra_packages: [telnet,netcat]
+# Extra Debian packages that are needed in the dbimage can be added here
+
+# use_dns_when_possible: true
+# If the host has internet access and the domain configured can
+# successfully be looked up, DNS will be used for hostname resolution
+# instead of editing /etc/hosts
+# Defaults to true
+
+# project_tld: ddev.site
+# The top-level domain used for project URLs
+# The default "ddev.site" allows DNS lookup via a wildcard
+# If you prefer you can change this to "ddev.local" to preserve
+# pre-v1.9 behavior.
+
+# ngrok_args: --basic-auth username:pass1234
+# Provide extra flags to the "ngrok http" command, see
+# https://ngrok.com/docs/ngrok-agent/config or run "ngrok http -h"
+
+# disable_settings_management: false
+# If true, DDEV will not create CMS-specific settings files like
+# Drupal's settings.php/settings.ddev.php or TYPO3's AdditionalConfiguration.php
+# In this case the user must provide all such settings.
+
+# You can inject environment variables into the web container with:
+# web_environment:
+# - SOMEENV=somevalue
+# - SOMEOTHERENV=someothervalue
+
+# no_project_mount: false
+# (Experimental) If true, DDEV will not mount the project into the web container;
+# the user is responsible for mounting it manually or via a script.
+# This is to enable experimentation with alternate file mounting strategies.
+# For advanced users only!
+
+# bind_all_interfaces: false
+# If true, host ports will be bound on all network interfaces,
+# not the localhost interface only. This means that ports
+# will be available on the local network if the host firewall
+# allows it.
+
+# default_container_timeout: 120
+# The default time that DDEV waits for all containers to become ready can be increased from
+# the default 120. This helps in importing huge databases, for example.
+
+#web_extra_exposed_ports:
+#- name: nodejs
+#  container_port: 3000
+#  http_port: 2999
+#  https_port: 3000
+#- name: something
+#  container_port: 4000
+#  https_port: 4000
+#  http_port: 3999
+# Allows a set of extra ports to be exposed via ddev-router
+# Fill in all three fields even if you don’t intend to use the https_port!
+# If you don’t add https_port, then it defaults to 0 and ddev-router will fail to start.
+#
+# The port behavior on the ddev-webserver must be arranged separately, for example
+# using web_extra_daemons.
+# For example, with a web app on port 3000 inside the container, this config would
+# expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
+# web_extra_exposed_ports:
+#  - name: myapp
+#    container_port: 3000
+#    http_port: 9998
+#    https_port: 9999
+
+#web_extra_daemons:
+#- name: "http-1"
+#  command: "/var/www/html/node_modules/.bin/http-server -p 3000"
+#  directory: /var/www/html
+#- name: "http-2"
+#  command: "/var/www/html/node_modules/.bin/http-server /var/www/html/sub -p 3000"
+#  directory: /var/www/html
+
+# override_config: false
+# By default, config.*.yaml files are *merged* into the configuration
+# But this means that some things can't be overridden
+# For example, if you have 'use_dns_when_possible: true'' you can't override it with a merge
+# and you can't erase existing hooks or all environment variables.
+# However, with "override_config: true" in a particular config.*.yaml file,
+# 'use_dns_when_possible: false' can override the existing values, and
+# hooks:
+#   post-start: []
+# or
+# web_environment: []
+# or
+# additional_hostnames: []
+# can have their intended affect. 'override_config' affects only behavior of the
+# config.*.yaml file it exists in.
+
+# Many DDEV commands can be extended to run tasks before or after the
+# DDEV command is executed, for example "post-start", "post-import-db",
+# "pre-composer", "post-composer"
+# See https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/ for more
+# information on the commands that can be extended and the tasks you can define
+# for them. Example:
+#hooks:

--- a/.ddev/docker-compose.opensearch.yaml
+++ b/.ddev/docker-compose.opensearch.yaml
@@ -1,0 +1,57 @@
+#ddev-generated
+version: '3.6'
+services:
+  opensearch:
+    container_name: ddev-${DDEV_SITENAME}-opensearch
+    hostname: ${DDEV_SITENAME}-opensearch
+    build: ./opensearch
+    expose:
+      - "9200"
+    networks: [default, ddev_default]
+    environment:
+      # disables installation of demo data
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      # disables security plugin
+      - "DISABLE_SECURITY_PLUGIN=true"
+      - cluster.name=docker-cluster
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=9200:9200
+      - HTTPS_EXPOSE=9201:9200
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    volumes:
+      - opensearch:/usr/share/opensearch/data
+      - ".:/mnt/ddev_config"
+
+  opensearch-dashboards:
+    image: opensearchproject/opensearch-dashboards:latest
+    container_name: 'ddev-${DDEV_SITENAME}-opensearch-dashboards'
+    hostname: '${DDEV_SITENAME}-opensearch-dashboards'
+    networks: [default, ddev_default]
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - OPENSEARCH_HOSTS=http://ddev-${DDEV_PROJECT}-opensearch:9200
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true" # disables security plugin
+      - SERVER_NAME=ddev-${DDEV_PROJECT}-opensearch
+      - HTTP_EXPOSE=5601:5601
+      - HTTPS_EXPOSE=5602:5601
+    expose:      
+      - "5601"
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    depends_on:
+      - opensearch
+
+  web:
+    depends_on:
+      - opensearch
+    links:
+      - 'opensearch:opensearch'      
+
+volumes:
+  opensearch:

--- a/.ddev/docker-compose.rabbitmq.yaml
+++ b/.ddev/docker-compose.rabbitmq.yaml
@@ -1,0 +1,28 @@
+#ddev-generated
+services:
+  rabbitmq:
+    container_name: ddev-${DDEV_SITENAME}-rabbitmq
+    hostname: ${DDEV_SITENAME}-rabbitmq
+    image: "rabbitmq:3-management-alpine"
+    expose:
+      - 15672
+    environment:
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      - HTTP_EXPOSE=15672
+      - HTTPS_EXPOSE=15673:15672
+      - RABBITMQ_ERLANG_COOKIE=SWQOKODSQALRPCLNMEQG
+      - RABBITMQ_DEFAULT_USER=rabbitmq
+      - RABBITMQ_DEFAULT_PASS=rabbitmq
+      - RABBITMQ_DEFAULT_VHOST=/
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    volumes:
+      - "rabbitmq:/var/lib/rabbitmq/mnesia"
+      - ".:/mnt/ddev_config"
+  web:
+    links:
+      - rabbitmq:rabbitmq
+volumes:
+  rabbitmq:
+    name: "${DDEV_SITENAME}_rabbitmq"

--- a/.ddev/docker-compose.redis.yaml
+++ b/.ddev/docker-compose.redis.yaml
@@ -1,0 +1,33 @@
+#ddev-generated
+volumes:
+  redis:
+    name: ddev-${DDEV_SITENAME}-redis
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+
+services:
+  redis:
+    container_name: ddev-${DDEV_SITENAME}-redis
+    hostname: ddev-${DDEV_SITENAME}-minio
+    image: redis:7.2-alpine
+    command: /etc/redis/conf/redis.conf
+    volumes:
+      - ".:/mnt/ddev_config"
+      - "./redis:/etc/redis/conf"
+      - "redis:/data"
+    expose:
+      - 6379
+    networks:
+      - default
+    deploy:
+      resources:
+        limits:
+          cpus: "2"
+          memory: "768M"
+        reservations:
+          cpus: "1"
+          memory: "512M"
+    restart: "no"
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT

--- a/.ddev/docker-compose.varnish-extras.yaml
+++ b/.ddev/docker-compose.varnish-extras.yaml
@@ -1,0 +1,15 @@
+#ddev-generated
+# This is the second half of the trick that puts varnish "in front of" the web
+# container, just by switching the names.
+
+
+
+
+
+
+
+services:
+  web:
+    environment:
+    - VIRTUAL_HOST=novarnish.performance-training.ddev.site
+

--- a/.ddev/docker-compose.varnish.yaml
+++ b/.ddev/docker-compose.varnish.yaml
@@ -1,0 +1,31 @@
+#ddev-generated
+services:
+  varnish:
+    container_name: ddev-${DDEV_SITENAME}-varnish
+    image: varnish:6.0
+    # These labels ensure this service is discoverable by ddev.
+    labels:
+      com.ddev.site-name: ${DDEV_SITENAME}
+      com.ddev.approot: $DDEV_APPROOT
+    environment:
+      # This defines the host name the service should be accessible from. This
+      # will be sitename.ddev.site.
+      # This is the first half of the trick that puts varnish "in front of" the
+      # web container, just by switching the names.
+      - VIRTUAL_HOST=$DDEV_HOSTNAME
+      # This defines the ports the service should be accessible from at
+      # sitename.ddev.site.
+      - HTTPS_EXPOSE=443:80,8026:8025
+      - HTTP_EXPOSE=80:80,8025:8025
+    volumes:
+      # This exposes a mount to the host system `.ddev/varnish` directory where
+      # your default.vcl should be.
+      - "./varnish:/etc/varnish"
+      - ".:/mnt/ddev_config"
+    depends_on:
+      - web
+    # Add mailhog support
+    expose:
+      - "8025"
+    entrypoint:
+      /usr/local/bin/docker-varnish-entrypoint -a 0.0.0.0:8025

--- a/.ddev/opensearch/Dockerfile
+++ b/.ddev/opensearch/Dockerfile
@@ -1,0 +1,5 @@
+FROM opensearchproject/opensearch:latest
+WORKDIR /usr/share/opensearch
+ 
+RUN bin/opensearch-plugin install analysis-phonetic
+RUN bin/opensearch-plugin install analysis-icu

--- a/.ddev/rabbitmq/config.yaml
+++ b/.ddev/rabbitmq/config.yaml
@@ -1,0 +1,25 @@
+#ddev-generated
+vhost:
+  - name: ddev-vhost
+    default-queue-type: classic
+queue:
+  - name: ddev-queue
+    vhost: ddev-vhost
+    durable: true
+  - name: ddev-additional
+    vhost: ddev-vhost
+    durable: true
+user:
+  - name: ddev-admin
+    password: password
+    tags:
+      - administrator
+      - management
+    permissions:
+      - vhost: ddev-vhost
+        conf: .*
+        write: .*
+        read: .*
+plugins:
+  # Required!
+  - rabbitmq_management

--- a/.ddev/rabbitmq/schema.json
+++ b/.ddev/rabbitmq/schema.json
@@ -1,0 +1,88 @@
+{
+  "#ddev-generated":true,
+  "$schema": "./config.yaml",
+  "type": "object",
+  "properties": {
+    "user": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "management",
+                "policymaker",
+                "monitoring",
+                "administrator"
+              ]
+            }
+          }
+        },
+        "required": ["name", "password", "tags"]
+      }
+    },
+    "queue": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "vhost": {
+            "type": "string",
+            "pattern": "^([a-zA-Z_\-\/]*)$"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^([a-zA-Z_-]*)$"
+          },
+          "durable": {
+            "type": "boolean"
+          }
+        },
+        "required": ["name"]
+      }
+    },
+    "plugins": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "vhost": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "pattern": "^([a-zA-Z_\-0-9]*)$"
+          },
+          "default-queue-type": {
+            "type": "string",
+            "enum": [
+              "classic",
+              "quorum",
+              "stream"
+            ]
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^([a-zA-Z_\-0-9]*)$"
+            }
+          }
+        },
+        "required": ["name", "default-queue-type"]
+      }
+    }
+  }
+}

--- a/.ddev/redis/advanced.conf
+++ b/.ddev/redis/advanced.conf
@@ -1,0 +1,341 @@
+# #ddev-generated
+############################### ADVANCED CONFIG ###############################
+
+# Hashes are encoded using a memory efficient data structure when they have a
+# small number of entries, and the biggest entry does not exceed a given
+# threshold. These thresholds can be configured using the following directives.
+hash-max-ziplist-entries 512
+hash-max-ziplist-value 64
+
+# Lists are also encoded in a special way to save a lot of space.
+# The number of entries allowed per internal list node can be specified
+# as a fixed maximum size or a maximum number of elements.
+# For a fixed maximum size, use -5 through -1, meaning:
+# -5: max size: 64 Kb  <-- not recommended for normal workloads
+# -4: max size: 32 Kb  <-- not recommended
+# -3: max size: 16 Kb  <-- probably not recommended
+# -2: max size: 8 Kb   <-- good
+# -1: max size: 4 Kb   <-- good
+# Positive numbers mean store up to _exactly_ that number of elements
+# per list node.
+# The highest performing option is usually -2 (8 Kb size) or -1 (4 Kb size),
+# but if your use case is unique, adjust the settings as necessary.
+list-max-ziplist-size -2
+
+# Lists may also be compressed.
+# Compress depth is the number of quicklist ziplist nodes from *each* side of
+# the list to *exclude* from compression.  The head and tail of the list
+# are always uncompressed for fast push/pop operations.  Settings are:
+# 0: disable all list compression
+# 1: depth 1 means "don't start compressing until after 1 node into the list,
+#    going from either the head or tail"
+#    So: [head]->node->node->...->node->[tail]
+#    [head], [tail] will always be uncompressed; inner nodes will compress.
+# 2: [head]->[next]->node->node->...->node->[prev]->[tail]
+#    2 here means: don't compress head or head->next or tail->prev or tail,
+#    but compress all nodes between them.
+# 3: [head]->[next]->[next]->node->node->...->node->[prev]->[prev]->[tail]
+# etc.
+list-compress-depth 0
+
+# Sets have a special encoding in just one case: when a set is composed
+# of just strings that happen to be integers in radix 10 in the range
+# of 64 bit signed integers.
+# The following configuration setting sets the limit in the size of the
+# set in order to use this special memory saving encoding.
+set-max-intset-entries 512
+
+# Similarly to hashes and lists, sorted sets are also specially encoded in
+# order to save a lot of space. This encoding is only used when the length and
+# elements of a sorted set are below the following limits:
+zset-max-ziplist-entries 128
+zset-max-ziplist-value 64
+
+# HyperLogLog sparse representation bytes limit. The limit includes the
+# 16 bytes header. When an HyperLogLog using the sparse representation crosses
+# this limit, it is converted into the dense representation.
+#
+# A value greater than 16000 is totally useless, since at that point the
+# dense representation is more memory efficient.
+#
+# The suggested value is ~ 3000 in order to have the benefits of
+# the space efficient encoding without slowing down too much PFADD,
+# which is O(N) with the sparse encoding. The value can be raised to
+# ~ 10000 when CPU is not a concern, but space is, and the data set is
+# composed of many HyperLogLogs with cardinality in the 0 - 15000 range.
+hll-sparse-max-bytes 3000
+
+# Streams macro node max size / items. The stream data structure is a radix
+# tree of big nodes that encode multiple items inside. Using this configuration
+# it is possible to configure how big a single node can be in bytes, and the
+# maximum number of items it may contain before switching to a new node when
+# appending new stream entries. If any of the following settings are set to
+# zero, the limit is ignored, so for instance it is possible to set just a
+# max entires limit by setting max-bytes to 0 and max-entries to the desired
+# value.
+stream-node-max-bytes 4096
+stream-node-max-entries 100
+
+# Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
+# order to help rehashing the main Redis hash table (the one mapping top-level
+# keys to values). The hash table implementation Redis uses (see dict.c)
+# performs a lazy rehashing: the more operation you run into a hash table
+# that is rehashing, the more rehashing "steps" are performed, so if the
+# server is idle the rehashing is never complete and some more memory is used
+# by the hash table.
+#
+# The default is to use this millisecond 10 times every second in order to
+# actively rehash the main dictionaries, freeing memory when possible.
+#
+# If unsure:
+# use "activerehashing no" if you have hard latency requirements and it is
+# not a good thing in your environment that Redis can reply from time to time
+# to queries with 2 milliseconds delay.
+#
+# use "activerehashing yes" if you don't have such hard requirements but
+# want to free memory asap when possible.
+activerehashing yes
+
+# The client output buffer limits can be used to force disconnection of clients
+# that are not reading data from the server fast enough for some reason (a
+# common reason is that a Pub/Sub client can't consume messages as fast as the
+# publisher can produce them).
+#
+# The limit can be set differently for the three different classes of clients:
+#
+# normal -> normal clients including MONITOR clients
+# replica  -> replica clients
+# pubsub -> clients subscribed to at least one pubsub channel or pattern
+#
+# The syntax of every client-output-buffer-limit directive is the following:
+#
+# client-output-buffer-limit <class> <hard limit> <soft limit> <soft seconds>
+#
+# A client is immediately disconnected once the hard limit is reached, or if
+# the soft limit is reached and remains reached for the specified number of
+# seconds (continuously).
+# So for instance if the hard limit is 32 megabytes and the soft limit is
+# 16 megabytes / 10 seconds, the client will get disconnected immediately
+# if the size of the output buffers reach 32 megabytes, but will also get
+# disconnected if the client reaches 16 megabytes and continuously overcomes
+# the limit for 10 seconds.
+#
+# By default normal clients are not limited because they don't receive data
+# without asking (in a push way), but just after a request, so only
+# asynchronous clients may create a scenario where data is requested faster
+# than it can read.
+#
+# Instead there is a default limit for pubsub and replica clients, since
+# subscribers and replicas receive data in a push fashion.
+#
+# Both the hard or the soft limit can be disabled by setting them to zero.
+client-output-buffer-limit normal 0 0 0
+client-output-buffer-limit replica 256mb 64mb 60
+client-output-buffer-limit pubsub 32mb 8mb 60
+
+# Client query buffers accumulate new commands. They are limited to a fixed
+# amount by default in order to avoid that a protocol desynchronization (for
+# instance due to a bug in the client) will lead to unbound memory usage in
+# the query buffer. However you can configure it here if you have very special
+# needs, such us huge multi/exec requests or alike.
+#
+# client-query-buffer-limit 1gb
+
+# In the Redis protocol, bulk requests, that are, elements representing single
+# strings, are normally limited to 512 mb. However you can change this limit
+# here, but must be 1mb or greater
+#
+# proto-max-bulk-len 512mb
+
+# Redis calls an internal function to perform many background tasks, like
+# closing connections of clients in timeout, purging expired keys that are
+# never requested, and so forth.
+#
+# Not all tasks are performed with the same frequency, but Redis checks for
+# tasks to perform according to the specified "hz" value.
+#
+# By default "hz" is set to 10. Raising the value will use more CPU when
+# Redis is idle, but at the same time will make Redis more responsive when
+# there are many keys expiring at the same time, and timeouts may be
+# handled with more precision.
+#
+# The range is between 1 and 500, however a value over 100 is usually not
+# a good idea. Most users should use the default of 10 and raise this up to
+# 100 only in environments where very low latency is required.
+hz 10
+
+# Normally it is useful to have an HZ value which is proportional to the
+# number of clients connected. This is useful in order, for instance, to
+# avoid too many clients are processed for each background task invocation
+# in order to avoid latency spikes.
+#
+# Since the default HZ value by default is conservatively set to 10, Redis
+# offers, and enables by default, the ability to use an adaptive HZ value
+# which will temporarily raise when there are many connected clients.
+#
+# When dynamic HZ is enabled, the actual configured HZ will be used
+# as a baseline, but multiples of the configured HZ value will be actually
+# used as needed once more clients are connected. In this way an idle
+# instance will use very little CPU time while a busy instance will be
+# more responsive.
+dynamic-hz yes
+
+# When a child rewrites the AOF file, if the following option is enabled
+# the file will be fsync-ed every 32 MB of data generated. This is useful
+# in order to commit the file to the disk more incrementally and avoid
+# big latency spikes.
+aof-rewrite-incremental-fsync yes
+
+# When redis saves RDB file, if the following option is enabled
+# the file will be fsync-ed every 32 MB of data generated. This is useful
+# in order to commit the file to the disk more incrementally and avoid
+# big latency spikes.
+rdb-save-incremental-fsync yes
+
+# Redis LFU eviction (see maxmemory setting) can be tuned. However it is a good
+# idea to start with the default settings and only change them after investigating
+# how to improve the performances and how the keys LFU change over time, which
+# is possible to inspect via the OBJECT FREQ command.
+#
+# There are two tunable parameters in the Redis LFU implementation: the
+# counter logarithm factor and the counter decay time. It is important to
+# understand what the two parameters mean before changing them.
+#
+# The LFU counter is just 8 bits per key, it's maximum value is 255, so Redis
+# uses a probabilistic increment with logarithmic behavior. Given the value
+# of the old counter, when a key is accessed, the counter is incremented in
+# this way:
+#
+# 1. A random number R between 0 and 1 is extracted.
+# 2. A probability P is calculated as 1/(old_value*lfu_log_factor+1).
+# 3. The counter is incremented only if R < P.
+#
+# The default lfu-log-factor is 10. This is a table of how the frequency
+# counter changes with a different number of accesses with different
+# logarithmic factors:
+#
+# +--------+------------+------------+------------+------------+------------+
+# | factor | 100 hits   | 1000 hits  | 100K hits  | 1M hits    | 10M hits   |
+# +--------+------------+------------+------------+------------+------------+
+# | 0      | 104        | 255        | 255        | 255        | 255        |
+# +--------+------------+------------+------------+------------+------------+
+# | 1      | 18         | 49         | 255        | 255        | 255        |
+# +--------+------------+------------+------------+------------+------------+
+# | 10     | 10         | 18         | 142        | 255        | 255        |
+# +--------+------------+------------+------------+------------+------------+
+# | 100    | 8          | 11         | 49         | 143        | 255        |
+# +--------+------------+------------+------------+------------+------------+
+#
+# NOTE: The above table was obtained by running the following commands:
+#
+#   redis-benchmark -n 1000000 incr foo
+#   redis-cli object freq foo
+#
+# NOTE 2: The counter initial value is 5 in order to give new objects a chance
+# to accumulate hits.
+#
+# The counter decay time is the time, in minutes, that must elapse in order
+# for the key counter to be divided by two (or decremented if it has a value
+# less <= 10).
+#
+# The default value for the lfu-decay-time is 1. A special value of 0 means to
+# decay the counter every time it happens to be scanned.
+#
+# lfu-log-factor 10
+# lfu-decay-time 1
+
+############################## DEBUG COMMAND #############################
+
+enable-debug-command yes
+
+########################### ACTIVE DEFRAGMENTATION #######################
+#
+# What is active defragmentation?
+# -------------------------------
+#
+# Active (online) defragmentation allows a Redis server to compact the
+# spaces left between small allocations and deallocations of data in memory,
+# thus allowing to reclaim back memory.
+#
+# Fragmentation is a natural process that happens with every allocator (but
+# less so with Jemalloc, fortunately) and certain workloads. Normally a server
+# restart is needed in order to lower the fragmentation, or at least to flush
+# away all the data and create it again. However thanks to this feature
+# implemented by Oran Agra for Redis 4.0 this process can happen at runtime
+# in a "hot" way, while the server is running.
+#
+# Basically when the fragmentation is over a certain level (see the
+# configuration options below) Redis will start to create new copies of the
+# values in contiguous memory regions by exploiting certain specific Jemalloc
+# features (in order to understand if an allocation is causing fragmentation
+# and to allocate it in a better place), and at the same time, will release the
+# old copies of the data. This process, repeated incrementally for all the keys
+# will cause the fragmentation to drop back to normal values.
+#
+# Important things to understand:
+#
+# 1. This feature is disabled by default, and only works if you compiled Redis
+#    to use the copy of Jemalloc we ship with the source code of Redis.
+#    This is the default with Linux builds.
+#
+# 2. You never need to enable this feature if you don't have fragmentation
+#    issues.
+#
+# 3. Once you experience fragmentation, you can enable this feature when
+#    needed with the command "CONFIG SET activedefrag yes".
+#
+# The configuration parameters are able to fine tune the behavior of the
+# defragmentation process. If you are not sure about what they mean it is
+# a good idea to leave the defaults untouched.
+
+# Enabled active defragmentation
+# activedefrag no
+
+# Minimum amount of fragmentation waste to start active defrag
+# active-defrag-ignore-bytes 100mb
+
+# Minimum percentage of fragmentation to start active defrag
+# active-defrag-threshold-lower 10
+
+# Maximum percentage of fragmentation at which we use maximum effort
+# active-defrag-threshold-upper 100
+
+# Minimal effort for defrag in CPU percentage, to be used when the lower
+# threshold is reached
+# active-defrag-cycle-min 1
+
+# Maximal effort for defrag in CPU percentage, to be used when the upper
+# threshold is reached
+# active-defrag-cycle-max 25
+
+# Maximum number of set/hash/zset/list fields that will be processed from
+# the main dictionary scan
+# active-defrag-max-scan-fields 1000
+
+# Jemalloc background thread for purging will be enabled by default
+jemalloc-bg-thread yes
+
+# It is possible to pin different threads and processes of Redis to specific
+# CPUs in your system, in order to maximize the performances of the server.
+# This is useful both in order to pin different Redis threads in different
+# CPUs, but also in order to make sure that multiple Redis instances running
+# in the same host will be pinned to different CPUs.
+#
+# Normally you can do this using the "taskset" command, however it is also
+# possible to this via Redis configuration directly, both in Linux and FreeBSD.
+#
+# You can pin the server/IO threads, bio threads, aof rewrite child process, and
+# the bgsave child process. The syntax to specify the cpu list is the same as
+# the taskset command:
+#
+# Set redis server/io threads to cpu affinity 0,2,4,6:
+# server_cpulist 0-7:2
+#
+# Set bio threads to cpu affinity 1,3:
+# bio_cpulist 1,3
+#
+# Set aof rewrite child process to cpu affinity 8,9,10,11:
+# aof_rewrite_cpulist 8-11
+#
+# Set bgsave child process to cpu affinity 1,10,11
+# bgsave_cpulist 1,10-11

--- a/.ddev/redis/append.conf
+++ b/.ddev/redis/append.conf
@@ -1,0 +1,133 @@
+# #ddev-generated
+############################## APPEND ONLY MODE ###############################
+
+# By default Redis asynchronously dumps the dataset on disk. This mode is
+# good enough in many applications, but an issue with the Redis process or
+# a power outage may result into a few minutes of writes lost (depending on
+# the configured save points).
+#
+# The Append Only File is an alternative persistence mode that provides
+# much better durability. For instance using the default data fsync policy
+# (see later in the config file) Redis can lose just one second of writes in a
+# dramatic event like a server power outage, or a single write if something
+# wrong with the Redis process itself happens, but the operating system is
+# still running correctly.
+#
+# AOF and RDB persistence can be enabled at the same time without problems.
+# If the AOF is enabled on startup Redis will load the AOF, that is the file
+# with the better durability guarantees.
+#
+# Please check http://redis.io/topics/persistence for more information.
+
+appendonly yes
+
+# The name of the append only file (default: "appendonly.aof")
+
+appendfilename "appendonly.aof"
+
+# For convenience, Redis stores all persistent append-only files in a dedicated
+# directory. The name of the directory is determined by the appenddirname
+# configuration parameter.
+
+appenddirname "append"
+
+# The fsync() call tells the Operating System to actually write data on disk
+# instead of waiting for more data in the output buffer. Some OS will really flush
+# data on disk, some other OS will just try to do it ASAP.
+#
+# Redis supports three different modes:
+#
+# no: don't fsync, just let the OS flush the data when it wants. Faster.
+# always: fsync after every write to the append only log. Slow, Safest.
+# everysec: fsync only one time every second. Compromise.
+#
+# The default is "everysec", as that's usually the right compromise between
+# speed and data safety. It's up to you to understand if you can relax this to
+# "no" that will let the operating system flush the output buffer when
+# it wants, for better performances (but if you can live with the idea of
+# some data loss consider the default persistence mode that's snapshotting),
+# or on the contrary, use "always" that's very slow but a bit safer than
+# everysec.
+#
+# More details please check the following article:
+# http://antirez.com/post/redis-persistence-demystified.html
+#
+# If unsure, use "everysec".
+
+appendfsync everysec
+
+# When the AOF fsync policy is set to always or everysec, and a background
+# saving process (a background save or AOF log background rewriting) is
+# performing a lot of I/O against the disk, in some Linux configurations
+# Redis may block too long on the fsync() call. Note that there is no fix for
+# this currently, as even performing fsync in a different thread will block
+# our synchronous write(2) call.
+#
+# In order to mitigate this problem it's possible to use the following option
+# that will prevent fsync() from being called in the main process while a
+# BGSAVE or BGREWRITEAOF is in progress.
+#
+# This means that while another child is saving, the durability of Redis is
+# the same as "appendfsync none". In practical terms, this means that it is
+# possible to lose up to 30 seconds of log in the worst scenario (with the
+# default Linux settings).
+#
+# If you have latency problems turn this to "yes". Otherwise leave it as
+# "no" that is the safest pick from the point of view of durability.
+
+no-appendfsync-on-rewrite no
+
+# Automatic rewrite of the append only file.
+# Redis is able to automatically rewrite the log file implicitly calling
+# BGREWRITEAOF when the AOF log size grows by the specified percentage.
+#
+# This is how it works: Redis remembers the size of the AOF file after the
+# latest rewrite (if no rewrite has happened since the restart, the size of
+# the AOF at startup is used).
+#
+# This base size is compared to the current size. If the current size is
+# bigger than the specified percentage, the rewrite is triggered. Also
+# you need to specify a minimal size for the AOF file to be rewritten, this
+# is useful to avoid rewriting the AOF file even if the percentage increase
+# is reached but it is still pretty small.
+#
+# Specify a percentage of zero in order to disable the automatic AOF
+# rewrite feature.
+
+auto-aof-rewrite-percentage 100
+auto-aof-rewrite-min-size 64mb
+
+# An AOF file may be found to be truncated at the end during the Redis
+# startup process, when the AOF data gets loaded back into memory.
+# This may happen when the system where Redis is running
+# crashes, especially when an ext4 filesystem is mounted without the
+# data=ordered option (however this can't happen when Redis itself
+# crashes or aborts but the operating system still works correctly).
+#
+# Redis can either exit with an error when this happens, or load as much
+# data as possible (the default now) and start if the AOF file is found
+# to be truncated at the end. The following option controls this behavior.
+#
+# If aof-load-truncated is set to yes, a truncated AOF file is loaded and
+# the Redis server starts emitting a log to inform the user of the event.
+# Otherwise if the option is set to no, the server aborts with an error
+# and refuses to start. When the option is set to no, the user requires
+# to fix the AOF file using the "redis-check-aof" utility before to restart
+# the server.
+#
+# Note that if the AOF file will be found to be corrupted in the middle
+# the server will still exit with an error. This option only applies when
+# Redis will try to read more data from the AOF file but not enough bytes
+# will be found.
+aof-load-truncated yes
+
+# When rewriting the AOF file, Redis is able to use an RDB preamble in the
+# AOF file for faster rewrites and recoveries. When this option is turned
+# on the rewritten AOF file is composed of two different stanzas:
+#
+#   [RDB file][AOF tail]
+#
+# When loading, Redis recognizes that the AOF file starts with the "REDIS"
+# string and loads the prefixed RDB file, then continues loading the AOF
+# tail.
+aof-use-rdb-preamble yes

--- a/.ddev/redis/general.conf
+++ b/.ddev/redis/general.conf
@@ -1,0 +1,44 @@
+# #ddev-generated
+################################# GENERAL #####################################
+
+# By default Redis does not run as a daemon. Use 'yes' if you need it.
+# Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
+daemonize no
+
+# If you run Redis from upstart or systemd, Redis can interact with your
+# supervision tree. Options:
+#   supervised no      - no supervision interaction
+#   supervised upstart - signal upstart by putting Redis into SIGSTOP mode
+#                        requires "expect stop" in your upstart job config
+#   supervised systemd - signal systemd by writing READY=1 to $NOTIFY_SOCKET
+#   supervised auto    - detect upstart or systemd method based on
+#                        UPSTART_JOB or NOTIFY_SOCKET environment variables
+# Note: these supervision methods only signal "process is ready."
+#       They do not enable continuous pings back to your supervisor.
+supervised no
+
+# Specify the server verbosity level.
+# This can be one of:
+# debug (a lot of information, useful for development/testing)
+# verbose (many rarely useful info, but not a mess like the debug level)
+# notice (moderately verbose, what you want in production probably)
+# warning (only very important / critical messages are logged)
+loglevel notice
+
+# Specify the log file name. Also the empty string can be used to force
+# Redis to log on the standard output. Note that if you use standard
+# output for logging but daemonize, logs will be sent to /dev/null
+logfile ""
+
+# Set the number of databases. The default database is DB 0, you can select
+# a different one on a per-connection basis using SELECT <dbid> where
+# dbid is a number between 0 and 'databases'-1
+databases 4
+
+# By default Redis shows an ASCII art logo only when started to log to the
+# standard output and if the standard output is a TTY. Basically this means
+# that normally a logo is displayed only in interactive sessions.
+#
+# However it is possible to force the pre-4.0 behavior and always show a
+# ASCII art logo in startup logs by setting the following option to yes.
+always-show-logo yes

--- a/.ddev/redis/io.conf
+++ b/.ddev/redis/io.conf
@@ -1,0 +1,98 @@
+# #ddev-generated
+################################ THREADED I/O #################################
+
+# Redis is mostly single threaded, however there are certain threaded
+# operations such as UNLINK, slow I/O accesses and other things that are
+# performed on side threads.
+#
+# Now it is also possible to handle Redis clients socket reads and writes
+# in different I/O threads. Since especially writing is so slow, normally
+# Redis users use pipelining in order to speed up the Redis performances per
+# core, and spawn multiple instances in order to scale more. Using I/O
+# threads it is possible to easily speedup two times Redis without resorting
+# to pipelining nor sharding of the instance.
+#
+# By default threading is disabled, we suggest enabling it only in machines
+# that have at least 4 or more cores, leaving at least one spare core.
+# Using more than 8 threads is unlikely to help much. We also recommend using
+# threaded I/O only if you actually have performance problems, with Redis
+# instances being able to use a quite big percentage of CPU time, otherwise
+# there is no point in using this feature.
+#
+# So for instance if you have a four cores boxes, try to use 2 or 3 I/O
+# threads, if you have a 8 cores, try to use 6 threads. In order to
+# enable I/O threads use the following configuration directive:
+#
+io-threads 1
+
+#
+# Setting io-threads to 1 will just use the main thread as usual.
+# When I/O threads are enabled, we only use threads for writes, that is
+# to thread the write(2) syscall and transfer the client buffers to the
+# socket. However it is also possible to enable threading of reads and
+# protocol parsing using the following configuration directive, by setting
+# it to yes:
+#
+io-threads-do-reads no
+
+#
+# Usually threading reads doesn't help much.
+#
+# NOTE 1: This configuration directive cannot be changed at runtime via
+# CONFIG SET. Aso this feature currently does not work when SSL is
+# enabled.
+#
+# NOTE 2: If you want to test the Redis speedup using redis-benchmark, make
+# sure you also run the benchmark itself in threaded mode, using the
+# --threads option to match the number of Redis threads, otherwise you'll not
+# be able to notice the improvements.
+
+############################ KERNEL OOM CONTROL ##############################
+
+# On Linux, it is possible to hint the kernel OOM killer on what processes
+# should be killed first when out of memory.
+#
+# Enabling this feature makes Redis actively control the oom_score_adj value
+# for all its processes, depending on their role. The default scores will
+# attempt to have background child processes killed before all others, and
+# replicas killed before masters.
+
+oom-score-adj no
+
+# When oom-score-adj is used, this directive controls the specific values used
+# for master, replica and background child processes. Values range -1000 to
+# 1000 (higher means more likely to be killed).
+#
+# Unprivileged processes (not root, and without CAP_SYS_RESOURCE capabilities)
+# can freely increase their value, but not decrease it below its initial
+# settings.
+#
+# Values are used relative to the initial value of oom_score_adj when the server
+# starts. Because typically the initial value is 0, they will often match the
+# absolute values.
+
+oom-score-adj-values 0 200 800
+
+################################## SLOW LOG ###################################
+
+# The Redis Slow Log is a system to log queries that exceeded a specified
+# execution time. The execution time does not include the I/O operations
+# like talking with the client, sending the reply and so forth,
+# but just the time needed to actually execute the command (this is the only
+# stage of command execution where the thread is blocked and can not serve
+# other requests in the meantime).
+#
+# You can configure the slow log with two parameters: one tells Redis
+# what is the execution time, in microseconds, to exceed in order for the
+# command to get logged, and the other parameter is the length of the
+# slow log. When a new command is logged the oldest one is removed from the
+# queue of logged commands.
+
+# The following time is expressed in microseconds, so 1000000 is equivalent
+# to one second. Note that a negative number disables the slow log, while
+# a value of zero forces the logging of every command.
+slowlog-log-slower-than 10000
+
+# There is no limit to this length. Just be aware that it will consume memory.
+# You can reclaim memory used by the slow log with SLOWLOG RESET.
+slowlog-max-len 128

--- a/.ddev/redis/memory.conf
+++ b/.ddev/redis/memory.conf
@@ -1,0 +1,142 @@
+# #ddev-generated
+############################## MEMORY MANAGEMENT ################################
+
+# Set a memory usage limit to the specified amount of bytes.
+# When the memory limit is reached Redis will try to remove keys
+# according to the eviction policy selected (see maxmemory-policy).
+#
+# If Redis can't remove keys according to the policy, or if the policy is
+# set to 'noeviction', Redis will start to reply with errors to commands
+# that would use more memory, like SET, LPUSH, and so on, and will continue
+# to reply to read-only commands like GET.
+#
+# This option is usually useful when using Redis as an LRU or LFU cache, or to
+# set a hard memory limit for an instance (using the 'noeviction' policy).
+#
+# WARNING: If you have replicas attached to an instance with maxmemory on,
+# the size of the output buffers needed to feed the replicas are subtracted
+# from the used memory count, so that network problems / resyncs will
+# not trigger a loop where keys are evicted, and in turn the output
+# buffer of replicas is full with DELs of keys evicted triggering the deletion
+# of more keys, and so forth until the database is completely emptied.
+#
+# In short... if you have replicas attached it is suggested that you set a lower
+# limit for maxmemory so that there is some free RAM on the system for replica
+# output buffers (but this is not needed if the policy is 'noeviction').
+#
+maxmemory 512mb
+
+# MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
+# is reached. You can select one from the following behaviors:
+#
+# volatile-lru -> Evict using approximated LRU, only keys with an expire set.
+# allkeys-lru -> Evict any key using approximated LRU.
+# volatile-lfu -> Evict using approximated LFU, only keys with an expire set.
+# allkeys-lfu -> Evict any key using approximated LFU.
+# volatile-random -> Remove a random key having an expire set.
+# allkeys-random -> Remove a random key, any key.
+# volatile-ttl -> Remove the key with the nearest expire time (minor TTL)
+# noeviction -> Don't evict anything, just return an error on write operations.
+#
+# LRU means Least Recently Used
+# LFU means Least Frequently Used
+#
+# Both LRU, LFU and volatile-ttl are implemented using approximated
+# randomized algorithms.
+#
+# Note: with any of the above policies, Redis will return an error on write
+#       operations, when there are no suitable keys for eviction.
+#
+#       At the date of writing these commands are: set setnx setex append
+#       incr decr rpush lpush rpushx lpushx linsert lset rpoplpush sadd
+#       sinter sinterstore sunion sunionstore sdiff sdiffstore zadd zincrby
+#       zunionstore zinterstore hset hsetnx hmset hincrby incrby decrby
+#       getset mset msetnx exec sort
+#
+# The default is:
+#
+maxmemory-policy allkeys-lru
+
+# LRU, LFU and minimal TTL algorithms are not precise algorithms but approximated
+# algorithms (in order to save memory), so you can tune it for speed or
+# accuracy. By default Redis will check five keys and pick the one that was
+# used least recently, you can change the sample size using the following
+# configuration directive.
+#
+# The default of 5 produces good enough results. 10 Approximates very closely
+# true LRU but costs more CPU. 3 is faster but not very accurate.
+#
+maxmemory-samples 4
+
+# Redis reclaims expired keys in two ways: upon access when those keys are
+# found to be expired, and also in background, in what is called the
+# "active expire key". The key space is slowly and interactively scanned
+# looking for expired keys to reclaim, so that it is possible to free memory
+# of keys that are expired and will never be accessed again in a short time.
+#
+# The default effort of the expire cycle will try to avoid having more than
+# ten percent of expired keys still in memory, and will try to avoid consuming
+# more than 25% of total memory and to add latency to the system. However
+# it is possible to increase the expire "effort" that is normally set to
+# "1", to a greater value, up to the value "10". At its maximum value the
+# system will use more CPU, longer cycles (and technically may introduce
+# more latency), and will tolerate less already expired keys still present
+# in the system. It's a tradeoff between memory, CPU and latency.
+#
+active-expire-effort 2
+
+############################# LAZY FREEING ####################################
+
+# Redis has two primitives to delete keys. One is called DEL and is a blocking
+# deletion of the object. It means that the server stops processing new commands
+# in order to reclaim all the memory associated with an object in a synchronous
+# way. If the key deleted is associated with a small object, the time needed
+# in order to execute the DEL command is very small and comparable to most other
+# O(1) or O(log_N) commands in Redis. However if the key is associated with an
+# aggregated value containing millions of elements, the server can block for
+# a long time (even seconds) in order to complete the operation.
+#
+# For the above reasons Redis also offers non blocking deletion primitives
+# such as UNLINK (non blocking DEL) and the ASYNC option of FLUSHALL and
+# FLUSHDB commands, in order to reclaim memory in background. Those commands
+# are executed in constant time. Another thread will incrementally free the
+# object in the background as fast as possible.
+#
+# DEL, UNLINK and ASYNC option of FLUSHALL and FLUSHDB are user-controlled.
+# It's up to the design of the application to understand when it is a good
+# idea to use one or the other. However the Redis server sometimes has to
+# delete keys or flush the whole database as a side effect of other operations.
+# Specifically Redis deletes objects independently of a user call in the
+# following scenarios:
+#
+# 1) On eviction, because of the maxmemory and maxmemory policy configurations,
+#    in order to make room for new data, without going over the specified
+#    memory limit.
+# 2) Because of expire: when a key with an associated time to live (see the
+#    EXPIRE command) must be deleted from memory.
+# 3) Because of a side effect of a command that stores data on a key that may
+#    already exist. For example the RENAME command may delete the old key
+#    content when it is replaced with another one. Similarly SUNIONSTORE
+#    or SORT with STORE option may delete existing keys. The SET command
+#    itself removes any old content of the specified key in order to replace
+#    it with the specified string.
+# 4) During replication, when a replica performs a full resynchronization with
+#    its master, the content of the whole database is removed in order to
+#    load the RDB file just transferred.
+#
+# In all the above cases the default is to delete objects in a blocking way,
+# like if DEL was called. However you can configure each case specifically
+# in order to instead release memory in a non-blocking way like if UNLINK
+# was called, using the following configuration directives.
+
+lazyfree-lazy-eviction no
+lazyfree-lazy-expire no
+lazyfree-lazy-server-del no
+replica-lazy-flush no
+
+# It is also possible, for the case when to replace the user code DEL calls
+# with UNLINK calls is not easy, to modify the default behavior of the DEL
+# command to act exactly like UNLINK, using the following configuration
+# directive:
+
+lazyfree-lazy-user-del no

--- a/.ddev/redis/network.conf
+++ b/.ddev/redis/network.conf
@@ -1,0 +1,85 @@
+# #ddev-generated
+################################## NETWORK #####################################
+
+# By default, if no "bind" configuration directive is specified, Redis listens
+# for connections from all available network interfaces on the host machine.
+# It is possible to listen to just one or multiple selected interfaces using
+# the "bind" configuration directive, followed by one or more IP addresses.
+#
+# Examples:
+#
+# bind 192.168.1.100 10.0.0.1
+# bind 127.0.0.1 ::1
+#
+# ~~~ WARNING ~~~ If the computer running Redis is directly exposed to the
+# internet, binding to all the interfaces is dangerous and will expose the
+# instance to everybody on the internet. So by default we uncomment the
+# following bind directive, that will force Redis to listen only on the
+# IPv4 loopback interface address (this means Redis will only be able to
+# accept client connections from the same host that it is running on).
+#
+# IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
+# JUST COMMENT OUT THE FOLLOWING LINE.
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+bind 0.0.0.0
+
+# Protected mode is a layer of security protection, in order to avoid that
+# Redis instances left open on the internet are accessed and exploited.
+#
+# When protected mode is on and if:
+#
+# 1) The server is not binding explicitly to a set of addresses using the
+#    "bind" directive.
+# 2) No password is configured.
+#
+# The server only accepts connections from clients connecting from the
+# IPv4 and IPv6 loopback addresses 127.0.0.1 and ::1, and from Unix domain
+# sockets.
+#
+# By default protected mode is enabled. You should disable it only if
+# you are sure you want clients from other hosts to connect to Redis
+# even if no authentication is configured, nor a specific set of interfaces
+# are explicitly listed using the "bind" directive.
+protected-mode yes
+
+# Accept connections on the specified port, default is 6379 (IANA #815344).
+# If port 0 is specified Redis will not listen on a TCP socket.
+port 6379
+
+# TCP listen() backlog.
+#
+# In high requests-per-second environments you need a high backlog in order
+# to avoid slow clients connection issues. Note that the Linux kernel
+# will silently truncate it to the value of /proc/sys/net/core/somaxconn so
+# make sure to raise both the value of somaxconn and tcp_max_syn_backlog
+# in order to get the desired effect.
+tcp-backlog 1024
+
+# Unix socket.
+#
+# Specify the path for the Unix socket that will be used to listen for
+# incoming connections. There is no default, so Redis will not listen
+# on a unix socket when not specified.
+#
+# unixsocket /tmp/redis.sock
+# unixsocketperm 700
+
+# Close the connection after a client is idle for N seconds (0 to disable)
+timeout 0
+
+# TCP keepalive.
+#
+# If non-zero, use SO_KEEPALIVE to send TCP ACKs to clients in absence
+# of communication. This is useful for two reasons:
+#
+# 1) Detect dead peers.
+# 2) Force network equipment in the middle to consider the connection to be
+#    alive.
+#
+# On Linux, the specified value (in seconds) is the period used to send ACKs.
+# Note that to close the connection the double of the time is needed.
+# On other kernels the period depends on the kernel configuration.
+#
+# A reasonable value for this option is 300 seconds, which is the new
+# Redis default starting with Redis 3.2.1.
+tcp-keepalive 300

--- a/.ddev/redis/redis.conf
+++ b/.ddev/redis/redis.conf
@@ -1,0 +1,26 @@
+# #ddev-generated
+################################## INCLUDES ###################################
+
+# Network
+include /etc/redis/conf/network.conf
+
+# General
+include /etc/redis/conf/general.conf
+
+# Snapshots
+include /etc/redis/conf/snapshots.conf
+
+# Security
+include /etc/redis/conf/security.conf
+
+# Memory management
+include /etc/redis/conf/memory.conf
+
+# CPU management
+include /etc/redis/conf/io.conf
+
+# Append mode
+include /etc/redis/conf/append.conf
+
+# Advanced config
+include /etc/redis/conf/advanced.conf

--- a/.ddev/redis/security.conf
+++ b/.ddev/redis/security.conf
@@ -1,0 +1,12 @@
+# #ddev-generated
+################################## SECURITY ###################################
+
+# Warning: since Redis is pretty fast, an outside user can try up to
+# 1 million passwords per second against a modern box. This means that you
+# should use very strong passwords, otherwise they will be very easy to break.
+# Note that because the password is really a shared secret between the client
+# and the server, and should not be memorized by any human, the password
+# can be easily a long string from /dev/urandom or whatever, so by using a
+# long and unguessable password no brute force attack will be possible.
+user default ~* &* +@all on >redis
+user redis ~* &* +@all on >redis

--- a/.ddev/redis/snapshots.conf
+++ b/.ddev/redis/snapshots.conf
@@ -1,0 +1,68 @@
+# #ddev-generated
+################################ SNAPSHOTTING  ################################
+#
+# Save the DB on disk:
+#
+#   save <seconds> <changes>
+#
+#   Will save the DB if both the given number of seconds and the given
+#   number of write operations against the DB occurred.
+#
+#   In the example below the behavior will be to save:
+#   after 300 sec (5 min) if at least 1 key changed
+#   after 150 sec (2.5 min) if at least 10 keys changed
+#   after 30 sec if at least 10000 keys changed
+#
+#   Note: you can disable saving completely by commenting out all "save" lines.
+#
+#   It is also possible to remove all the previously configured save
+#   points by adding a save directive with a single empty string argument
+#   like in the following example:
+#
+#   save ""
+save 300 1
+save 150 10
+save 30 10000
+
+# By default Redis will stop accepting writes if RDB snapshots are enabled
+# (at least one save point) and the latest background save failed.
+# This will make the user aware (in a hard way) that data is not persisting
+# on disk properly, otherwise chances are that no one will notice and some
+# disaster will happen.
+#
+# If the background saving process will start working again Redis will
+# automatically allow writes again.
+#
+# However if you have setup your proper monitoring of the Redis server
+# and persistence, you may want to disable this feature so that Redis will
+# continue to work as usual even if there are problems with disk,
+# permissions, and so forth.
+stop-writes-on-bgsave-error yes
+
+# Compress string objects using LZF when dump .rdb databases?
+# By default compression is enabled as it's almost always a win.
+# If you want to save some CPU in the saving child set it to 'no' but
+# the dataset will likely be bigger if you have compressible values or keys.
+rdbcompression yes
+
+# Since version 5 of RDB a CRC64 checksum is placed at the end of the file.
+# This makes the format more resistant to corruption but there is a performance
+# hit to pay (around 10%) when saving and loading RDB files, so you can disable it
+# for maximum performances.
+#
+# RDB files created with checksum disabled have a checksum of zero that will
+# tell the loading code to skip the check.
+rdbchecksum yes
+
+# The filename where to dump the DB
+dbfilename performance-training.rdb
+
+# The working directory.
+#
+# The DB will be written inside this directory, with the filename specified
+# above using the 'dbfilename' configuration directive.
+#
+# The Append Only File will also be created inside this directory.
+#
+# Note that you must specify a directory here, not a file name.
+dir /data

--- a/.ddev/varnish/default.vcl
+++ b/.ddev/varnish/default.vcl
@@ -1,0 +1,255 @@
+# VCL version 5.0 is not supported so it should be 4.0 even though actually used Varnish version is 6
+vcl 4.0;
+
+import std;
+# The minimal Varnish version is 6.0
+# For SSL offloading, pass the following header in your proxy server or load balancer: 'X-Forwarded-Proto: https'
+
+backend default {
+    .host = "web";
+    .port = "80";
+    .first_byte_timeout = 600s;
+    .probe = {
+        .url = "/health_check.php";
+        .timeout = 2s;
+        .interval = 5s;
+        .window = 10;
+        .threshold = 5;
+   }
+}
+
+acl purge {
+    "localhost";
+}
+
+sub vcl_recv {
+    if (req.restarts > 0) {
+        set req.hash_always_miss = true;
+    }
+
+    if (req.method == "PURGE") {
+        if (client.ip !~ purge) {
+            return (synth(405, "Method not allowed"));
+        }
+        # To use the X-Pool header for purging varnish during automated deployments, make sure the X-Pool header
+        # has been added to the response in your backend server config. This is used, for example, by the
+        # capistrano-magento2 gem for purging old content from varnish during it's deploy routine.
+        if (!req.http.X-Magento-Tags-Pattern && !req.http.X-Pool) {
+            return (synth(400, "X-Magento-Tags-Pattern or X-Pool header required"));
+        }
+        if (req.http.X-Magento-Tags-Pattern) {
+          ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern);
+        }
+        if (req.http.X-Pool) {
+          ban("obj.http.X-Pool ~ " + req.http.X-Pool);
+        }
+        return (synth(200, "Purged"));
+    }
+
+    if (req.method != "GET" &&
+        req.method != "HEAD" &&
+        req.method != "PUT" &&
+        req.method != "POST" &&
+        req.method != "TRACE" &&
+        req.method != "OPTIONS" &&
+        req.method != "DELETE") {
+          /* Non-RFC2616 or CONNECT which is weird. */
+          return (pipe);
+    }
+
+    # We only deal with GET and HEAD by default
+    if (req.method != "GET" && req.method != "HEAD") {
+        return (pass);
+    }
+
+    # Bypass customer, shopping cart, checkout
+    if (req.url ~ "/customer" || req.url ~ "/checkout") {
+        return (pass);
+    }
+
+    # Bypass health check requests
+    if (req.url ~ "^/(pub/)?(health_check.php)$") {
+        return (pass);
+    }
+
+    # Set initial grace period usage status
+    set req.http.grace = "none";
+
+    # normalize url in case of leading HTTP scheme and domain
+    set req.url = regsub(req.url, "^http[s]?://", "");
+
+    # collect all cookies
+    std.collect(req.http.Cookie);
+
+    # Compression filter. See https://www.varnish-cache.org/trac/wiki/FAQ/Compression
+    if (req.http.Accept-Encoding) {
+        if (req.url ~ "\.(jpg|jpeg|png|gif|gz|tgz|bz2|tbz|mp3|ogg|swf|flv)$") {
+            # No point in compressing these
+            unset req.http.Accept-Encoding;
+        } elsif (req.http.Accept-Encoding ~ "gzip") {
+            set req.http.Accept-Encoding = "gzip";
+        } elsif (req.http.Accept-Encoding ~ "deflate" && req.http.user-agent !~ "MSIE") {
+            set req.http.Accept-Encoding = "deflate";
+        } else {
+            # unknown algorithm
+            unset req.http.Accept-Encoding;
+        }
+    }
+
+    # Remove all marketing get parameters to minimize the cache objects
+    if (req.url ~ "(\?|&)(gclid|cx|ie|cof|siteurl|zanpid|origin|fbclid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+)=") {
+        set req.url = regsuball(req.url, "(gclid|cx|ie|cof|siteurl|zanpid|origin|fbclid|mc_[a-z]+|utm_[a-z]+|_bta_[a-z]+)=[-_A-z0-9+()%.]+&?", "");
+        set req.url = regsub(req.url, "[?|&]+$", "");
+    }
+
+    # Static files caching
+    if (req.url ~ "^/(pub/)?(media|static)/") {
+        # Static files should not be cached by default
+        return (pass);
+
+        # But if you use a few locales and don't use CDN you can enable caching static files by commenting previous line (#return (pass);) and uncommenting next 3 lines
+        #unset req.http.Https;
+        #unset req.http.X-Forwarded-Proto;
+        #unset req.http.Cookie;
+    }
+
+    # Bypass authenticated GraphQL requests without a X-Magento-Cache-Id
+    if (req.url ~ "/graphql" && !req.http.X-Magento-Cache-Id && req.http.Authorization ~ "^Bearer") {
+        return (pass);
+    }
+
+    return (hash);
+}
+
+sub vcl_hash {
+    if ((req.url !~ "/graphql" || !req.http.X-Magento-Cache-Id) && req.http.cookie ~ "X-Magento-Vary=") {
+        hash_data(regsub(req.http.cookie, "^.*?X-Magento-Vary=([^;]+);*.*$", "\1"));
+    }
+
+    # To make sure http users don't see ssl warning
+    if (req.http.X-Forwarded-Proto) {
+        hash_data(req.http.X-Forwarded-Proto);
+    }
+
+
+    if (req.url ~ "/graphql") {
+        call process_graphql_headers;
+    }
+}
+
+sub process_graphql_headers {
+    if (req.http.X-Magento-Cache-Id) {
+        hash_data(req.http.X-Magento-Cache-Id);
+
+        # When the frontend stops sending the auth token, make sure users stop getting results cached for logged-in users
+        if (req.http.Authorization ~ "^Bearer") {
+            hash_data("Authorized");
+        }
+    }
+
+    if (req.http.Store) {
+        hash_data(req.http.Store);
+    }
+
+    if (req.http.Content-Currency) {
+        hash_data(req.http.Content-Currency);
+    }
+}
+
+sub vcl_backend_response {
+
+    set beresp.grace = 3d;
+
+    if (beresp.http.content-type ~ "text") {
+        set beresp.do_esi = true;
+    }
+
+    if (bereq.url ~ "\.js$" || beresp.http.content-type ~ "text") {
+        set beresp.do_gzip = true;
+    }
+
+    if (beresp.http.X-Magento-Debug) {
+        set beresp.http.X-Magento-Cache-Control = beresp.http.Cache-Control;
+    }
+
+    # cache only successfully responses and 404s that are not marked as private
+    if (beresp.status != 200 &&
+            beresp.status != 404 &&
+            beresp.http.Cache-Control ~ "private") {
+        set beresp.uncacheable = true;
+        set beresp.ttl = 86400s;
+        return (deliver);
+    }
+
+    # validate if we need to cache it and prevent from setting cookie
+    if (beresp.ttl > 0s && (bereq.method == "GET" || bereq.method == "HEAD")) {
+        unset beresp.http.set-cookie;
+    }
+
+   # If page is not cacheable then bypass varnish for 2 minutes as Hit-For-Pass
+   if (beresp.ttl <= 0s ||
+       beresp.http.Surrogate-control ~ "no-store" ||
+       (!beresp.http.Surrogate-Control &&
+       beresp.http.Cache-Control ~ "no-cache|no-store") ||
+       beresp.http.Vary == "*") {
+        # Mark as Hit-For-Pass for the next 2 minutes
+        set beresp.ttl = 120s;
+        set beresp.uncacheable = true;
+   }
+
+   # If the cache key in the Magento response doesn't match the one that was sent in the request, don't cache under the request's key
+   if (bereq.url ~ "/graphql" && bereq.http.X-Magento-Cache-Id && bereq.http.X-Magento-Cache-Id != beresp.http.X-Magento-Cache-Id) {
+      set beresp.ttl = 0s;
+      set beresp.uncacheable = true;
+   }
+
+    return (deliver);
+}
+
+sub vcl_deliver {
+    if (resp.http.x-varnish ~ " ") {
+        set resp.http.X-Magento-Cache-Debug = "HIT";
+        set resp.http.Grace = req.http.grace;
+    } else {
+        set resp.http.X-Magento-Cache-Debug = "MISS";
+    }
+
+    # Not letting browser to cache non-static files.
+    if (resp.http.Cache-Control !~ "private" && req.url !~ "^/(pub/)?(media|static)/") {
+        set resp.http.Pragma = "no-cache";
+        set resp.http.Expires = "-1";
+        set resp.http.Cache-Control = "no-store, no-cache, must-revalidate, max-age=0";
+    }
+
+    if (!resp.http.X-Magento-Debug) {
+        unset resp.http.Age;
+    }
+    unset resp.http.X-Magento-Debug;
+    unset resp.http.X-Magento-Tags;
+    unset resp.http.X-Powered-By;
+    unset resp.http.Server;
+    unset resp.http.X-Varnish;
+    unset resp.http.Via;
+    unset resp.http.Link;
+}
+
+sub vcl_hit {
+    if (obj.ttl >= 0s) {
+        # Hit within TTL period
+        return (deliver);
+    }
+    if (std.healthy(req.backend_hint)) {
+        if (obj.ttl + 300s > 0s) {
+            # Hit after TTL expiration, but within grace period
+            set req.http.grace = "normal (healthy server)";
+            return (deliver);
+        } else {
+            # Hit after TTL and grace expiration
+            return (restart);
+        }
+    } else {
+        # server is not healthy, retrieve from cache
+        set req.http.grace = "unlimited (unhealthy server)";
+        return (deliver);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,19 +2,35 @@
 
 Shirt store with large number of simple products assigned to each configurable.
 
-# Variations
+## Variations
 
 - Small (~5k SKU)
 - Medium (~ 26k SKU)
 - Large (~ 260k SKU)
 
+## Installation
 
-# Installation
-If you have warden installed and properly configured:
+### DDEV
+
+If you have [DDEV](https://ddev.com/) installed and properly configured:
+
+`ddev start`
+
+### Warden
+
+If you have [Warden](https://warden.dev/) installed and properly configured:
 
 `make`
 
-# Switching to another dataset
+## Switching to another dataset
+
+### DDEV
+
+- `ddev small` will use small database
+- `ddev medium` will use medium database
+- `ddev large` will use large database
+
+### Warden
 
 - `make small` will use small database
 - `make medium` will use medium database


### PR DESCRIPTION
This pull request introduces compatibility for utilizing the environment with https://ddev.com/.

The code remains unchanged; rather, it has been duplicated and adjusted to function. This is evident in the commands, for instance.

Upon inspection, the sole discrepancy I identified is that Warden employs the subdomain `app.performance-training`, which, in the case of DDEV, has not been incorporated without any apparent justification. However, it can be seamlessly integrated if deemed necessary.